### PR TITLE
some changes to serialization

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:diagram_editor/diagram_editor.dart';
@@ -40,12 +42,20 @@ class _DiagramAppState extends State<DiagramApp> {
                         child: const Text('delete all')),
                     const Spacer(),
                     ElevatedButton(
-                        onPressed: () => myPolicySet.serialize(),
-                        child: const Text('serialize')),
+                        onPressed: () => myPolicySet.serializeStringDiagram(),
+                        child: const Text('serialize string DiagramData')),
                     const SizedBox(width: 8),
                     ElevatedButton(
-                        onPressed: () => myPolicySet.deserialize(),
-                        child: const Text('deserialize')),
+                        onPressed: () => myPolicySet.deserializeStringDiagram(),
+                        child: const Text('deserialize string DiagramData')),
+                    const Spacer(),
+                    ElevatedButton(
+                        onPressed: () => myPolicySet.serializeObjectDiagram(),
+                        child: const Text('serialize object DiagramData')),
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                        onPressed: () => myPolicySet.deserializeObjectDiagram(),
+                        child: const Text('deserialize object DiagramData')),
                   ],
                 ),
               ),
@@ -219,6 +229,7 @@ mixin MyComponentPolicy implements ComponentPolicy, CustomPolicy {
 mixin CustomPolicy implements PolicySet {
   String? selectedComponentId;
   String serializedDiagram = '{"components": [], "links": []}';
+  DiagramData diagramData = DiagramData.empty();
 
   highlightComponent(String componentId) {
     canvasReader.model.getComponent(componentId).data.showHighlight();
@@ -240,17 +251,98 @@ mixin CustomPolicy implements PolicySet {
   }
 
   // Save the diagram to String in json format.
-  serialize() {
+  // To choose an another option, uncomment it and comment the other options in serializeStringDiagram() and deserializeStringDiagram() methods.
+  serializeStringDiagram() {
+    //Option 1: DiagramData as String serialized in variable
     serializedDiagram = canvasReader.model.serializeDiagram();
+
+    //Option 2: DiagramData as String serialized in file as single value
+    // serializedDiagram = canvasReader.model.serializeDiagram();
+    // File('C:/Users/prozhar/Desktop/sting_single.json')
+    //     .writeAsStringSync(serializedDiagramString);
+
+    //Option 3: DiagramData as String serialized in file as child value
+    // serializedDiagram = canvasReader.model.serializeDiagram();
+    // Map<String, dynamic> parentData = {
+    //   'id': 1,
+    //   'name': 'diagram_string',
+    //   'diagram_data': serializedDiagramString,
+    // };
+    // File('C:/Users/prozhar/Desktop/string_in_parent.json')
+    //     .writeAsStringSync(jsonEncode(parentData));
   }
 
   // Load the diagram from json format. Do it cautiously, to prevent unstable state remove the previous diagram (id collision can happen).
-  deserialize() {
-    canvasWriter.model.removeAllComponents();
+  // To choose an another option, uncomment it and comment the other options in serializeStringDiagram() and deserializeStringDiagram() methods.
+  deserializeStringDiagram() {
+    //Option 1: deserialize DiagramData as String from variable
     canvasWriter.model.deserializeDiagram(
       serializedDiagram,
       decodeCustomComponentData: MyComponentData.fromJson,
       decodeCustomLinkData: null,
     );
+
+    //Option 2: deserialize DiagramData as String from file as single value
+    // serializedDiagram = File('C:/Users/prozhar/Desktop/sting_single.json').readAsStringSync();
+    // canvasWriter.model.deserializeDiagram(
+    //   serializedDiagram,
+    //   decodeCustomComponentData: MyComponentData.fromJson,
+    //   decodeCustomLinkData: null,
+    // );
+
+    //Option 3: deserialize DiagramData as String from file as child value
+    // Map<String, dynamic> parentJson = jsonDecode(File('C:/Users/prozhar/Desktop/string_in_parent.json').readAsStringSync());
+    // serializedDiagram = parentJson['diagram_data'];
+    // canvasWriter.model.deserializeDiagram(
+    //   serializedDiagram,
+    //   decodeCustomComponentData: MyComponentData.fromJson,
+    //   decodeCustomLinkData: null,
+    // );
+  }
+
+  // Save the diagram to Object.
+  // To choose an another option, uncomment it and comment the other options in serializeObjectDiagram() and deserializeObjectDiagram() methods.
+  serializeObjectDiagram() {
+    //Option 1: DiagramData as Object serialized in variable
+    diagramData = canvasReader.model.getDiagram();
+
+    //Option 2: DiagramData as Object serialized in file as single value
+    // diagramData = canvasReader.model.getDiagram();
+    // File('C:/Users/prozhar/Desktop/object_single.json')
+    //     .writeAsStringSync(jsonEncode(diagramData));
+
+    //Option 3: DiagramData as Object serialized in file as child value
+    // diagramData = canvasReader.model.getDiagram();
+    // Map<String, dynamic> parentData = {
+    //   'id': 1,
+    //   'name': 'diagram_object',
+    //   'diagram_data': diagramData,
+    // };
+    // File('C:/Users/prozhar/Desktop/object_in_parent.json')
+    //     .writeAsStringSync(jsonEncode(parentData));
+  }
+
+  // Load the diagram from json format. Do it cautiously, to prevent unstable state remove the previous diagram (id collision can happen).
+  // To choose an another option, uncomment it and comment the other options in serializeObjectDiagram() and deserializeObjectDiagram() methods.
+  deserializeObjectDiagram() {
+    //Option 1: deserialize DiagramData as Object from variable
+    canvasWriter.model.setDiagram(diagramData);
+
+    //Option 2: deserialize DiagramData as Object from file as single value
+    // diagramData = DiagramData.fromJson(
+    //   jsonDecode(File('C:/Users/prozhar/Desktop/object_single.json').readAsStringSync()),
+    //   decodeCustomComponentData: MyComponentData.fromJson,
+    //   decodeCustomLinkData: null,
+    // );
+    // canvasWriter.model.setDiagram(diagramData);
+
+    //Option 3: deserialize DiagramData as Object from file as child value
+    // Map<String, dynamic> parentJson = jsonDecode(File('C:/Users/prozhar/Desktop/object_in_parent.json').readAsStringSync());
+    // diagramData = DiagramData.fromJson(
+    //   parentJson['diagram_data'],
+    //   decodeCustomComponentData: MyComponentData.fromJson,
+    //   decodeCustomLinkData: null,
+    // );
+    // canvasWriter.model.setDiagram(diagramData);
   }
 }

--- a/example/main.dart
+++ b/example/main.dart
@@ -258,7 +258,7 @@ mixin CustomPolicy implements PolicySet {
 
     //Option 2: DiagramData as String serialized in file as single value
     // serializedDiagram = canvasReader.model.serializeDiagram();
-    // File('C:/Users/prozhar/Desktop/sting_single.json')
+    // File('...put your directory path here.../sting_single.json')
     //     .writeAsStringSync(serializedDiagramString);
 
     //Option 3: DiagramData as String serialized in file as child value
@@ -268,7 +268,7 @@ mixin CustomPolicy implements PolicySet {
     //   'name': 'diagram_string',
     //   'diagram_data': serializedDiagramString,
     // };
-    // File('C:/Users/prozhar/Desktop/string_in_parent.json')
+    // File('...put your directory path here.../string_in_parent.json')
     //     .writeAsStringSync(jsonEncode(parentData));
   }
 
@@ -283,7 +283,7 @@ mixin CustomPolicy implements PolicySet {
     );
 
     //Option 2: deserialize DiagramData as String from file as single value
-    // serializedDiagram = File('C:/Users/prozhar/Desktop/sting_single.json').readAsStringSync();
+    // serializedDiagram = File('...put your directory path here.../sting_single.json').readAsStringSync();
     // canvasWriter.model.deserializeDiagram(
     //   serializedDiagram,
     //   decodeCustomComponentData: MyComponentData.fromJson,
@@ -291,7 +291,7 @@ mixin CustomPolicy implements PolicySet {
     // );
 
     //Option 3: deserialize DiagramData as String from file as child value
-    // Map<String, dynamic> parentJson = jsonDecode(File('C:/Users/prozhar/Desktop/string_in_parent.json').readAsStringSync());
+    // Map<String, dynamic> parentJson = jsonDecode(File('...put your directory path here.../string_in_parent.json').readAsStringSync());
     // serializedDiagram = parentJson['diagram_data'];
     // canvasWriter.model.deserializeDiagram(
     //   serializedDiagram,
@@ -308,7 +308,7 @@ mixin CustomPolicy implements PolicySet {
 
     //Option 2: DiagramData as Object serialized in file as single value
     // diagramData = canvasReader.model.getDiagram();
-    // File('C:/Users/prozhar/Desktop/object_single.json')
+    // File('...put your directory path here.../object_single.json')
     //     .writeAsStringSync(jsonEncode(diagramData));
 
     //Option 3: DiagramData as Object serialized in file as child value
@@ -318,7 +318,7 @@ mixin CustomPolicy implements PolicySet {
     //   'name': 'diagram_object',
     //   'diagram_data': diagramData,
     // };
-    // File('C:/Users/prozhar/Desktop/object_in_parent.json')
+    // File('...put your directory path here.../object_in_parent.json')
     //     .writeAsStringSync(jsonEncode(parentData));
   }
 
@@ -330,14 +330,14 @@ mixin CustomPolicy implements PolicySet {
 
     //Option 2: deserialize DiagramData as Object from file as single value
     // diagramData = DiagramData.fromJson(
-    //   jsonDecode(File('C:/Users/prozhar/Desktop/object_single.json').readAsStringSync()),
+    //   jsonDecode(File('...put your directory path here.../object_single.json').readAsStringSync()),
     //   decodeCustomComponentData: MyComponentData.fromJson,
     //   decodeCustomLinkData: null,
     // );
     // canvasWriter.model.setDiagram(diagramData);
 
     //Option 3: deserialize DiagramData as Object from file as child value
-    // Map<String, dynamic> parentJson = jsonDecode(File('C:/Users/prozhar/Desktop/object_in_parent.json').readAsStringSync());
+    // Map<String, dynamic> parentJson = jsonDecode(File('...put your directory path here.../object_in_parent.json').readAsStringSync());
     // diagramData = DiagramData.fromJson(
     //   parentJson['diagram_data'],
     //   decodeCustomComponentData: MyComponentData.fromJson,

--- a/lib/diagram_editor.dart
+++ b/lib/diagram_editor.dart
@@ -19,6 +19,7 @@ export 'src/canvas_context/diagram_editor_context.dart';
 export 'src/canvas_context/model/component_data.dart';
 export 'src/canvas_context/model/connection.dart';
 export 'src/canvas_context/model/link_data.dart';
+export 'src/canvas_context/model/diagram_data.dart';
 export 'src/utils/link_style.dart';
 export 'src/utils/painter/grid_painter.dart';
 export 'src/utils/painter/rect_highlight_painter.dart';

--- a/lib/src/abstraction_layer/rw/model_reader.dart
+++ b/lib/src/abstraction_layer/rw/model_reader.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:diagram_editor/diagram_editor.dart';
 import 'package:diagram_editor/src/canvas_context/canvas_model.dart';
 import 'package:diagram_editor/src/canvas_context/canvas_state.dart';
 import 'package:diagram_editor/src/canvas_context/model/component_data.dart';
@@ -65,6 +66,13 @@ class CanvasModelReader {
   ) {
     return canvasModel.getLink(linkId).determineLinkSegmentIndex(
         tapPosition, canvasState.position, canvasState.scale);
+  }
+
+  /// Returns [DiagramData] that contains components/links.
+  ///
+  /// To serialize dynamic data of components/links [toJson] function must be defined.
+  DiagramData getDiagram() {
+    return canvasModel.getDiagram();
   }
 
   /// Returns [String] that contains serialized diagram in JSON format.

--- a/lib/src/abstraction_layer/rw/model_writer.dart
+++ b/lib/src/abstraction_layer/rw/model_writer.dart
@@ -72,6 +72,12 @@ class CanvasModelWriter extends ModelWriter
     _canvasModel.removeAllLinks();
   }
 
+  /// Removes all components and links
+  /// Set all components and links from [diagram]
+  setDiagram(DiagramData diagram) {
+    _canvasModel.setDiagram(diagram);
+  }
+
   /// Loads a diagram from json string.
   ///
   /// !!! Beware of passing correct json string.
@@ -87,14 +93,7 @@ class CanvasModelWriter extends ModelWriter
       decodeCustomComponentData: decodeCustomComponentData,
       decodeCustomLinkData: decodeCustomLinkData,
     );
-    for (final componentData in diagram.components) {
-      _canvasModel.components[componentData.id] = componentData;
-    }
-    for (final linkData in diagram.links) {
-      _canvasModel.links[linkData.id] = linkData;
-      linkData.updateLink();
-    }
-    _canvasModel.updateCanvas();
+    _canvasModel.setDiagram(diagram);
   }
 }
 

--- a/lib/src/canvas_context/canvas_model.dart
+++ b/lib/src/canvas_context/canvas_model.dart
@@ -24,6 +24,20 @@ class CanvasModel with ChangeNotifier {
     );
   }
 
+  /// Removes all components and links
+  /// Set all components and links from [diagram]
+  setDiagram(DiagramData diagram) {
+    removeAllComponents();
+    for (final componentData in diagram.components) {
+      components[componentData.id] = componentData;
+    }
+    for (final linkData in diagram.links) {
+      links[linkData.id] = linkData;
+      linkData.updateLink();
+    }
+    updateCanvas();
+  }
+
   updateCanvas() {
     notifyListeners();
   }

--- a/lib/src/canvas_context/model/diagram_data.dart
+++ b/lib/src/canvas_context/model/diagram_data.dart
@@ -10,6 +10,10 @@ class DiagramData {
     required this.links,
   });
 
+  DiagramData.empty()
+      : this.components = <ComponentData>[],
+        this.links = <LinkData>[];
+
   DiagramData.fromJson(
     Map<String, dynamic> json, {
     Function(Map<String, dynamic> json)? decodeCustomComponentData,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -185,5 +185,5 @@ packages:
     source: hosted
     version: "2.1.1"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.15.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://arokip.github.io/fdl_demo_app
 repository: https://github.com/Arokip/flutter_diagram_editor
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
Hi. For now, it has two options of serialization:
1. Serialize to String as you implemented
2. Serialize to Object with access to `DiagramData` class
and 3 options with storage serialized data.

Why it needed? Because in case 1 (serialize to String with `serializeStringDiagram()` method) and saved option 3 (data stored as child in `ParentData` class) we have a problem with readable file:
- it look like this, because `ParentData` class also used `jsonEncode()` method - all doublequotes with backslash:
![1](https://user-images.githubusercontent.com/9317340/151757089-4d55d186-4ca7-4d1c-a966-3afc30f052d1.png)

So if we use the `getDiagram()` method, we can solve this problem. We will also have more options for programmatically creating a diagram data (case 2 : serialize to Object with `serializeObjectDiagram()`, option 3  (data stored as child in `ParentData` class):
-it looks more readable:
![2](https://user-images.githubusercontent.com/9317340/151758064-a8dc4493-cad1-4703-8362-2c687056168b.png)


