### PR TITLE
refactor: change color serialization to Json approach

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -85,7 +85,11 @@ class MyComponentData {
   // Function used to serialization of the diagram. E.g. to save to a file.
   Map<String, dynamic> toJson() => {
         'highlight': isHighlightVisible,
-        'color': color.toString().split('(0x')[1].split(')')[0],
+        'color': (((color.a * 255).round() << 24) |
+                ((color.r * 255).round() << 16) |
+                ((color.g * 255).round() << 8) |
+                ((color.b * 255).round()))
+            .toRadixString(16),
       };
 }
 

--- a/lib/src/utils/link_style.dart
+++ b/lib/src/utils/link_style.dart
@@ -266,6 +266,10 @@ class LinkStyle {
         'arrow_size': arrowSize,
         'back_arrow_size': backArrowSize,
         'line_width': lineWidth,
-        'color': color.toString().split('(0x')[1].split(')')[0],
+        'color': (((color.a * 255).round() << 24) |
+                ((color.r * 255).round() << 16) |
+                ((color.g * 255).round() << 8) |
+                ((color.b * 255).round()))
+            .toRadixString(16),
       };
 }


### PR DESCRIPTION
This refactor updates the color serialization method to a JSON-compatible format due to changes in the Color.toString() representation in Flutter 3.27.0.

**Reason for Change**
Flutter 3.27.0 introduced a breaking change in the Color.toString() representation, affecting how colors are serialized. The previous approach, which extracted the color from Color.toString(), is no longer reliable. (See Flutter's release notes: [Wide Gamut Framework Changes](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework))

**Impact**
1. Ensures compatibility with Flutter 3.27.0 and future versions.
2. No changes to functionality beyond serialization formatting.
